### PR TITLE
[fix] 도커 빌드가 실패하는 문제를 해결했습니다.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ WORKDIR /app
 RUN npm install -g serve
 
 # Copy built assets and expose the service port
-COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/build ./build
 EXPOSE 30002
 
 # Serve the production build for the reverse proxy
-CMD ["serve", "-s", "dist", "-l", "30002", "--single"]
+CMD ["serve", "-s", "build", "-l", "30002", "--single"]


### PR DESCRIPTION
존재하지도 않는 dist 파일을 복사하던걸 build를 복사하도록 변경했습니다.